### PR TITLE
Build multi-platform binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,56 @@
+# Based on the "trust" template v0.1.2
+# https://github.com/japaric/trust/tree/v0.1.2
+
+dist: trusty
 language: rust
-
-rust:
-  - stable
-  - beta
-  - nightly
-
-matrix:
-  allow_failures:
-    - rust: nightly
-  fast_finish: true
-
-cache: cargo
+services: docker
+sudo: required
 
 env:
-  - VAULT_ADDR=http://127.0.0.1:8200
+  global:
+    - CRATE_NAME=vdot
+
+matrix:
+  include:
+    # Linux
+    - env: TARGET=x86_64-unknown-linux-musl
+
+    # OSX
+    - env: TARGET=x86_64-apple-darwin
+      os: osx
 
 before_install:
-  - rustup component add rustfmt
-  - wget https://releases.hashicorp.com/vault/1.0.3/vault_1.0.3_linux_amd64.zip
-  - unzip vault_1.0.3_linux_amd64.zip
+  - set -e
+  - rustup self update
 
-before_script:
-  - echo "hunter2" > ~/.vault-token
-  - /sbin/start-stop-daemon --start --quiet --background --make-pidfile --pidfile "$PWD/vault.pid" --exec "$PWD/vault" -- server -dev -dev-root-token-id=hunter2
-  - sleep 2
-  - ./vault secrets enable -version=1 kv
-  - ./vault kv put kv/foo-bar ENV=production
-  - ./vault kv put kv/fizz-buzz LOG_LEVEL=info
+install:
+  - sh ci/install.sh
+  - source ~/.cargo/env || true
 
 script:
-  - cargo fmt -- --check
-  - cargo test
-  - cargo run -- --help
-  - cargo run -- kv/foo-bar kv/fizz-buzz
+  - cross build --target "$TARGET"
+  - cross test --target "$TARGET"
+
+after_script: set +e
+
+before_deploy:
+  - sh ci/before_deploy.sh
+
+deploy:
+  provider: releases
+  api_key:
+    secure: PRlzw2nxqDXJlI2MXmob7VGB0sE4w9Y9SnsPGC8Ot7zhAP/Dxvcdu8ZZepjVsie5WZK5V0mlNw6siEvjgWQmKo4BZKV/JVLRoF+XIQp5RcZFNA9ooUf86iMElPZSWjm4RR1eQUtr6tssyPCRnFOhnm4fIbb2cQ/5nJq6MTxIz8K9odqU5cRp6WBTkfIbYWBkXKrs2KObe/RwxWrQQMu8nHNxXAaSNvfuZOqCnaWraqZ9zKN04WFw1Gv6gftXy6UUUeeKB43x9TZiPXNwq5nDGJxCTFDiKT2zdQv2eOns1287cgCYOkLkEJRiQPFYbh9xJ8XaP18VaYsSH3Bjupql++xbgsHgNtfktepZAxyItoQ5jDcMCanJYCpZAOKtfAgSP6MSmLA+O5asJMcll7yYIY94J6YRRx9J5Fm/E56bq9RUWjr1Z15oxyOJlaEShqpdR9dJ6gGtxnJhLeL9azcF6meLERZA+V3+aHj1/5Swhtor0W1yUkkuXKm0/OCemsUi08zFmtwuOB/lo6d23y3jtN0hRexMZPUpuBpqXxwwFWKKVwA2kCxSs13OS+qF7M1dGDi2+2qNGCZ2mh4+4pf9+R/30Da78Fq0/xaVCqsgzfU9KWX4jORkuTc+LyqUGELNbZv0d3Gmf1igyrPlW1bItTJokMrmbxuo4mxSwymSHas=
+  file_glob: true
+  file: $CRATE_NAME-$TRAVIS_TAG-$TARGET.*
+  on:
+    condition: $TRAVIS_RUST_VERSION = stable
+    tags: true
+  skip_cleanup: true
+
+cache: cargo
+before_cache:
+  # Travis can't cache files that are not readable by "others"
+  - chmod -R a+r $HOME/.cargo
+
+notifications:
+  email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,55 @@
+# Based on the "trust" template v0.1.2
+# https://github.com/japaric/trust/tree/v0.1.2
+
+environment:
+  global:
+    RUST_VERSION: stable
+    CRATE_NAME: vdot
+
+  matrix:
+    # MSVC
+    - TARGET: i686-pc-windows-msvc
+    - TARGET: x86_64-pc-windows-msvc
+
+install:
+  - ps: >-
+      If ($Env:TARGET -eq 'x86_64-pc-windows-gnu') {
+        $Env:PATH += ';C:\msys64\mingw64\bin'
+      } ElseIf ($Env:TARGET -eq 'i686-pc-windows-gnu') {
+        $Env:PATH += ';C:\msys64\mingw32\bin'
+      }
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -Vv
+  - cargo -V
+
+test_script:
+  - cargo build --target %TARGET%
+  - cargo test --target %TARGET%
+
+before_deploy:
+  - cargo rustc --target %TARGET% --release --bin vdot -- -C lto
+  - ps: ci\before_deploy.ps1
+
+deploy:
+  artifact: /.*\.zip/
+  auth_token:
+    secure: CsdL/CTbBWyPqXHKCABx6DpWFUE/4BVoXxGkT1ArTd6UtJCzh+plitVSmGeq0yQq
+  description: ''
+  on:
+    RUST_VERSION: stable
+    appveyor_repo_tag: true
+  provider: GitHub
+
+cache:
+  - C:\Users\appveyor\.cargo\registry
+  - target
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+
+# Building is done in the test phase, so we disable Appveyor's build phase.
+build: false

--- a/ci/before_deploy.ps1
+++ b/ci/before_deploy.ps1
@@ -1,0 +1,22 @@
+# This script takes care of packaging the build artifacts that will go in the
+# release zipfile
+
+$SRC_DIR = $PWD.Path
+$STAGE = [System.Guid]::NewGuid().ToString()
+
+Set-Location $ENV:Temp
+New-Item -Type Directory -Name $STAGE
+Set-Location $STAGE
+
+$ZIP = "$SRC_DIR\$($Env:CRATE_NAME)-$($Env:APPVEYOR_REPO_TAG_NAME)-$($Env:TARGET).zip"
+
+Copy-Item "$SRC_DIR\target\$($Env:TARGET)\release\vdot.exe" '.\'
+
+7z a "$ZIP" *
+
+Push-AppveyorArtifact "$ZIP"
+
+Remove-Item *.* -Force
+Set-Location ..
+Remove-Item $STAGE
+Set-Location $SRC_DIR

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This script takes care of building your crate and packaging it for release
+
+set -ex
+
+main() {
+    local src=
+    local stage=
+
+    src="$(pwd)"
+
+    case $TRAVIS_OS_NAME in
+        linux)
+            stage=$(mktemp -d)
+            ;;
+        osx)
+            stage=$(mktemp -d -t tmp)
+            ;;
+    esac
+
+    test -f Cargo.lock || cargo generate-lockfile
+
+    cross rustc --bin vdot --target "$TARGET" --release -- -C lto
+
+    cp "target/$TARGET/release/vdot" "$stage/"
+
+    cd "$stage"
+    tar czf "$src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz" ./*
+    cd "$src"
+
+    rm -rf "$stage"
+}
+
+main

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -ex
+
+main() {
+    local target=
+    if [ "$TRAVIS_OS_NAME" = linux ]; then
+        target=x86_64-unknown-linux-musl
+        sort=sort
+    else
+        target=x86_64-apple-darwin
+        sort=gsort  # for `sort --sort-version`, from brew's coreutils.
+    fi
+
+    # Builds for iOS are done on OSX, but require the specific target to be
+    # installed.
+    case $TARGET in
+        aarch64-apple-ios)
+            rustup target install aarch64-apple-ios
+            ;;
+        armv7-apple-ios)
+            rustup target install armv7-apple-ios
+            ;;
+        armv7s-apple-ios)
+            rustup target install armv7s-apple-ios
+            ;;
+        i386-apple-ios)
+            rustup target install i386-apple-ios
+            ;;
+        x86_64-apple-ios)
+            rustup target install x86_64-apple-ios
+            ;;
+    esac
+
+    # This fetches latest stable release
+    local tag=
+    tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
+                       | cut -d/ -f3 \
+                       | grep -E '^v[0.1.0-9.]+$' \
+                       | "$sort" --version-sort \
+                       | tail -n1)
+
+    curl -LSfs https://japaric.github.io/trust/install.sh | \
+        sh -s -- \
+           --force \
+           --git japaric/cross \
+           --tag "$tag" \
+           --target "$target"
+}
+
+main


### PR DESCRIPTION
Use the https://github.com/japaric/trust framework to build and publish binaries for Windows, Linux, and macOS.

They'll end up published on each release at https://github.com/sjparkinson/vdot/releases.

https://ci.appveyor.com/project/sjparkinson/vdot

https://travis-ci.org/sjparkinson/vdot

Resolves #2.