### PR TITLE
Add a Homebrew tap

### DIFF
--- a/.github/tap-release.yml
+++ b/.github/tap-release.yml
@@ -1,0 +1,18 @@
+tap: sjparkinson/vdot/vdot.rb
+asset: vdot-$VERSION-x86_64-apple-darwin.tar.gz
+template: |
+  class Vdot < Formula
+    desc "$REPO_DESCRIPTION"
+    homepage "$REPO_WEBSITE"
+
+    url "$STABLE_ASSET_URL"
+    sha256 "$STABLE_ASSET_SHA256"
+
+    def install
+      bin.install "vdot"
+    end
+
+    test do
+      system "#{bin}/vdot", "--help"
+    end
+  end

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Create your `.env` files and start processes using Vault.
 
 ## Installation
 
-**Homebrew** or **Linuxbrew**
+**Homebrew**
 
 ```shell
 brew tap sjparkinson/vdot https://github.com/sjparkinson/vdot
@@ -23,7 +23,7 @@ cargo install vdot
 
 **Download**
 
-You can download the executable manually from https://github.com/sjparkinson/vdot/releases/latest.
+You can download executables manually from https://github.com/sjparkinson/vdot/releases/latest.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,12 @@ Create your `.env` files and start processes using Vault.
 
 ## Installation
 
-**macOS** and **Linux**
-
-This script will download the latest release from GitHub and install `vdot` under `/usr/local/bin`.
+**Homebrew** or **Linuxbrew**
 
 ```shell
-curl https://gist.githubusercontent.com/sjparkinson/327dc78c60ab81a06c946630b4288910/raw/crate-gh-install.sh \
-| sh -s -- --git sjparkinson/vdot
+brew tap sjparkinson/vdot https://github.com/sjparkinson/vdot
+brew install vdot
 ```
-
-You can also download the executable manually from https://github.com/sjparkinson/vdot/releases/latest.
 
 **Cargo**
 
@@ -24,6 +20,10 @@ You can also download the executable manually from https://github.com/sjparkinso
 ```shell
 cargo install vdot
 ```
+
+**Download**
+
+You can download the executable manually from https://github.com/sjparkinson/vdot/releases/latest.
 
 ## Usage
 

--- a/vdot.rb
+++ b/vdot.rb
@@ -1,0 +1,20 @@
+class Vdot < Formula
+  desc "Create your .env files and start processes using Vault"
+  homepage "https://github.com/sjparkinson/vdot"
+
+  if OS.mac?
+    url "https://github.com/sjparkinson/vdot/releases/download/v0.3.4/vdot-v0.3.4-x86_64-apple-darwin.tar.gz"
+    sha256 "4898d033b8d48ec0a960dd8d54f79324e26f7649d21718fb320a75e218fd94b0"
+  elsif OS.linux?
+    url "https://github.com/sjparkinson/vdot/releases/download/v0.3.4/vdot-v0.3.4-x86_64-unknown-linux-musl.tar.gz"
+    sha256 "f4dd7845dc319038b34fcc50327628f123dfea1aee1e8d5e767836bd86559c1e"
+  end
+
+  def install
+    bin.install "vdot"
+  end
+
+  test do
+    system "#{bin}/vdot", "--help"
+  end
+end

--- a/vdot.rb
+++ b/vdot.rb
@@ -2,13 +2,8 @@ class Vdot < Formula
   desc "Create your .env files and start processes using Vault"
   homepage "https://github.com/sjparkinson/vdot"
 
-  if OS.mac?
-    url "https://github.com/sjparkinson/vdot/releases/download/v0.3.4/vdot-v0.3.4-x86_64-apple-darwin.tar.gz"
-    sha256 "4898d033b8d48ec0a960dd8d54f79324e26f7649d21718fb320a75e218fd94b0"
-  elsif OS.linux?
-    url "https://github.com/sjparkinson/vdot/releases/download/v0.3.4/vdot-v0.3.4-x86_64-unknown-linux-musl.tar.gz"
-    sha256 "f4dd7845dc319038b34fcc50327628f123dfea1aee1e8d5e767836bd86559c1e"
-  end
+  url "https://github.com/sjparkinson/vdot/releases/download/v0.3.4/vdot-v0.3.4-x86_64-apple-darwin.tar.gz"
+  sha256 "4898d033b8d48ec0a960dd8d54f79324e26f7649d21718fb320a75e218fd94b0"
 
   def install
     bin.install "vdot"


### PR DESCRIPTION
Use the Tap Releases GitHub App to keep it up to date.

Basic tap that installs from binaries published to the GitHub releases.