### PR TITLE
feat: add Windows build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{rs}]
+[*.{rs,ps1}]
 indent_style = space
 indent_size = 4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ addons:
 before_install:
   - rustup target add "$TARGET"
   - rustup component add rustfmt clippy
+  - cargo fmt --version
+  - cargo clippy -V
 
 install:
   - cargo build --target "$TARGET"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vdot
 
-[![Build Status](https://travis-ci.org/sjparkinson/vdot.svg?branch=master)](https://travis-ci.org/sjparkinson/vdot)
+[![Build Status](https://travis-ci.org/sjparkinson/vdot.svg?branch=master)](https://travis-ci.org/sjparkinson/vdot) [![Build status](https://ci.appveyor.com/api/projects/status/jdi9mkoeauoa1ike/branch/master?svg=true)](https://ci.appveyor.com/project/sjparkinson/vdot/branch/master)
 
 Create your `.env` files and start processes using Vault.
 
@@ -25,7 +25,7 @@ cargo install vdot
 
 **Download**
 
-You can download `vdot` executables for macOS and Linux from https://github.com/sjparkinson/vdot/releases/latest.
+You can download executables for macOS, Linux, and Windows from https://github.com/sjparkinson/vdot/releases/latest.
 
 ## Usage
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,46 @@
+# Based on the "trust" template v0.1.2
+# https://github.com/japaric/trust/tree/v0.1.2
+
+environment:
+  matrix:
+    - TARGET: x86_64-pc-windows-msvc
+
+install:
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init -y --default-toolchain stable --default-host %TARGET%
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - rustup component add rustfmt clippy
+  - rustc -vV
+  - cargo -vV
+  - cargo fmt --version
+  - cargo clippy -V
+
+build_script:
+  - cargo build --target %TARGET%
+
+test_script:
+  - cargo fmt -- --check
+  - cargo clippy --target %TARGET%
+  - cargo test --target %TARGET%
+
+before_deploy:
+  - cargo build --target %TARGET% --release
+  - ps: scripts\before_deploy.ps1
+
+deploy:
+  artifact: /.*\.zip/
+  auth_token:
+    secure: CsdL/CTbBWyPqXHKCABx6DpWFUE/4BVoXxGkT1ArTd6UtJCzh+plitVSmGeq0yQq
+  description: ''
+  on:
+    appveyor_repo_tag: true
+  provider: GitHub
+
+cache:
+  - C:\Users\appveyor\.cargo\registry
+  - target
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false

--- a/scripts/before_deploy.ps1
+++ b/scripts/before_deploy.ps1
@@ -1,0 +1,24 @@
+# This script takes care of packaging the build artifacts that will go in the
+# release zipfile
+
+$SRC_DIR = $PWD.Path
+$STAGE = [System.Guid]::NewGuid().ToString()
+
+Set-Location $ENV:Temp
+New-Item -Type Directory -Name $STAGE
+Set-Location $STAGE
+
+$ZIP = "$SRC_DIR\vdot-$($Env:APPVEYOR_REPO_TAG_NAME)-$($Env:TARGET).zip"
+
+Copy-Item "$SRC_DIR\target\$($Env:TARGET)\release\vdot.exe" '.\'
+Copy-Item "$SRC_DIR\README.md" '.\'
+Copy-Item "$SRC_DIR\LICENSE" '.\'
+
+7z a "$ZIP" *
+
+Push-AppveyorArtifact "$ZIP"
+
+Remove-Item *.* -Force
+Set-Location ..
+Remove-Item $STAGE
+Set-Location $SRC_DIR


### PR DESCRIPTION
Use AppVeyor to run the vdot build on Windows.

Will add a `vdot.exe` to the release artifacts.