### PR TITLE
chore(ci): fix the Remove-Item error in the Windows build

### DIFF
--- a/scripts/before_deploy.ps1
+++ b/scripts/before_deploy.ps1
@@ -18,7 +18,4 @@ Copy-Item "$SRC_DIR\LICENSE" '.\'
 
 Push-AppveyorArtifact "$ZIP"
 
-Remove-Item *.* -Force
-Set-Location ..
-Remove-Item $STAGE
 Set-Location $SRC_DIR


### PR DESCRIPTION
Fix the following error in the before_deploy PowerShell script.

> Remove-Item : The method or operation is not implemented.

https://ci.appveyor.com/project/sjparkinson/vdot/builds/23473390#L252