### PR TITLE
Remove the --comand option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,6 @@ structopt = "0.2.15"
 url = "1.7.2"
 
 [profile.release]
-lto = true
+opt-level = 's'
+lto = 'fat'
 panic = 'abort'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # vdot
 
-Create your `.env` files and start processes using HashiCorp Vault.
+Create your `.env` files using HashiCorp Vault.
+
+> 🔮 **Want to start a process with Vault?** Consider using [HashiCorp's `envconsul`](https://github.com/hashicorp/envconsul).
 
 ## Installation
 
@@ -39,7 +41,6 @@ FLAGS:
     -v, --verbose    Verbose mode
 
 OPTIONS:
-    -c, --command <command>                Command to spawn
     -o, --output <output>                  Write to the given file [default: .env]
         --vault-address <vault_address>    Vault server address [env: VAULT_ADDR]
         --vault-token <vault_token>        Vault token used to authenticate requests [env: VAULT_TOKEN]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufWriter;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use structopt::StructOpt;
 use url::Url;
 
@@ -46,14 +45,6 @@ pub struct Args {
     )]
     pub output: PathBuf,
 
-    /// Command to spawn
-    ///
-    /// This option will spawn the given command with the environment variables downloaded from Vault.
-    ///
-    /// e.g. `vdot -c 'npm start' secret/foo`
-    #[structopt(short = "c", long = "command", conflicts_with = "output")]
-    pub command: Option<String>,
-
     /// Vault token used to authenticate requests
     ///
     /// This can also be provided by setting the VAULT_TOKEN environment variable.
@@ -90,7 +81,6 @@ pub struct Args {
 /// let args = Args {
 ///     paths: vec![],
 ///     output: PathBuf::from(".env"),
-///     command: None,
 ///     vault_token: "hunter2".to_string(),
 ///     vault_address: url::Url::parse("http://127.0.0.1:8200").unwrap(),
 ///     verbose: 0
@@ -166,25 +156,7 @@ pub fn run(args: Args) -> Result<(), Error> {
         }
     }
 
-    if let Some(command) = args.command {
-        return start_process(command, vars);
-    }
-
     save_dotenv(args.output, vars)
-}
-
-fn start_process(process: String, vars: HashMap<String, String>) -> Result<(), Error> {
-    let mut command = process.split_whitespace();
-
-    info!("running `{}`", process);
-
-    // The first part is the process to start.
-    Command::new(command.next().unwrap())
-        .args(command)
-        .envs(vars)
-        .status()?;
-
-    Ok(())
 }
 
 fn save_dotenv(path: PathBuf, vars: HashMap<String, String>) -> Result<(), Error> {


### PR DESCRIPTION
HashiCorp maintains a specific tool for this use case called [envconsul][1], and going with the [Unix philosophy of "Do One Thing and Do It Well"][2] it seems better for vdot to focus on generating .env files.

[1]: https://github.com/hashicorp/envconsul
[2]: https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well

Closes #35.